### PR TITLE
Fix tvctl distorting ntsc image when cea608 enabed

### DIFF
--- a/cea608.c
+++ b/cea608.c
@@ -52,7 +52,7 @@ void draw(uint8_t *image, int next_resource)
 {
     // fill image
     if(next_resource == 0) {
-        get_packet(ROW(image, 1)+FIXED, ROW(image, 0)+FIXED);
+        get_packet(ROW(image, 0)+FIXED, ROW(image, 1)+FIXED);
     }
 }
 

--- a/cea608.c
+++ b/cea608.c
@@ -33,7 +33,8 @@
 #include "cea608buffer.h"
 
 #define WIDTH (53)
-#define HEIGHT (2)
+#define VOFFSET (1)
+#define HEIGHT (VOFFSET+2)
 #define OFFSET (1)
 #define FIXED (19)
 #define ROW(i, n) (i+(PITCH(WIDTH)*(n))+OFFSET)
@@ -52,7 +53,7 @@ void draw(uint8_t *image, int next_resource)
 {
     // fill image
     if(next_resource == 0) {
-        get_packet(ROW(image, 0)+FIXED, ROW(image, 1)+FIXED);
+        get_packet(ROW(image, VOFFSET)+FIXED, ROW(image, VOFFSET + 1)+FIXED);
     }
 }
 
@@ -62,7 +63,7 @@ void init(uint8_t *image)
     // initialize image buffer with clock run in
     int n, m, clock = 0x61555;
     for (m=0; m<FIXED; m++) {
-        for (n=0; n<HEIGHT; n++) {
+        for (n=VOFFSET; n<HEIGHT; n++) {
             ROW(image, n)[m] = clock&1;
         }
         clock = clock >> 1;

--- a/tvctl.c
+++ b/tvctl.c
@@ -65,7 +65,7 @@ int try_set_regs(volatile unsigned int *regs, int argc, char *argv[])
         state = PAL_ON;
     else if (regs[5] == 0x00100003 && regs[6] == 0x000300f0 && regs[7] == 0x00100003 && regs[8] == 0x000400f0)
         state = NTSC_OFF;
-    else if (regs[5] == 0x000e0003 && regs[6] == 0x000500f0 && regs[7] == 0x000f0003 && regs[8] == 0x000500f0)
+    else if (regs[5] == 0x000e0003 && regs[6] == 0x000500f0 && regs[7] == 0x000e0003 && regs[8] == 0x000600f0)
         state = NTSC_ON;
     else
         state = UNKNOWN;
@@ -88,8 +88,8 @@ int try_set_regs(volatile unsigned int *regs, int argc, char *argv[])
             case NTSC_OFF:
                 regs[5] = 0x000e0003;
                 regs[6] = 0x000500f0;
-                regs[7] = 0x000f0003;
-                regs[8] = 0x000500f0;
+                regs[7] = 0x000e0003;
+                regs[8] = 0x000600f0;
                 /* fallthrough */
             case NTSC_ON:
                 fprintf(stderr, "CEA608 output is now on.\n");


### PR DESCRIPTION
This reverts 8d7bd58 and implements an alternative fix to insert the data in the correct lines without affecting the video output itself.
Unfortunately I cannot test it myself because none of the NTSC capable TVs I own displays CC subtitles.
